### PR TITLE
Update code.gs

### DIFF
--- a/jira-create-issue/code.gs
+++ b/jira-create-issue/code.gs
@@ -109,4 +109,8 @@ function createIssue(e){
   MailApp.sendEmail(requesterEmail, emailSubject, emailBody, {
     name: "<MAILBOX_NAME>"
   })
+// Assign Additional Watcher not just the requestor
+  var options2 = options
+  options2.payload = JSON.stringify("<MAILBOX_NAME>")
+  var response = UrlFetchApp.fetch(url + issueKey + "/watchers", options2);
  }


### PR DESCRIPTION
Adds a user as a watcher of an issue by passing the account Username/Email. 
This operation requires the Allow users to watch issues option to be ON. This option is set in General configuration for Jira. See Configuring Jira application options for details. Supported in Jira API v2/3.

https://developer.atlassian.com/cloud/jira/platform/rest/v2/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-issue-issueIdOrKey-watchers-get